### PR TITLE
Adding --once argument to test-packages command

### DIFF
--- a/start_test.js
+++ b/start_test.js
@@ -2,7 +2,7 @@
 var spawn = require('child_process').spawn;
 
 var packageDir = process.env.PACKAGE_DIR || './';
-var meteor = spawn('mrt', ['test-packages', '--driver-package', 'test-in-console', '-p', 10015, './'], {cwd: packageDir});
+var meteor = spawn('mrt', ['test-packages', '--once', '--driver-package', 'test-in-console', '-p', 10015, './'], {cwd: packageDir});
 meteor.stdout.pipe(process.stdout);
 meteor.stderr.pipe(process.stderr);
 


### PR DESCRIPTION
So that meteor fails if there is an error and not waits for file change: https://github.com/meteor/meteor/issues/1189#issuecomment-25072673
