### PR TITLE
Forward mrt exit code to make

### DIFF
--- a/start_test.js
+++ b/start_test.js
@@ -5,6 +5,10 @@ var packageDir = process.env.PACKAGE_DIR || './';
 var meteor = spawn('mrt', ['test-packages', '--once', '--driver-package', 'test-in-console', '-p', 10015, './'], {cwd: packageDir});
 meteor.stdout.pipe(process.stdout);
 meteor.stderr.pipe(process.stderr);
+meteor.on('close', function (code) {
+  console.log('mrt exited with code ' + code);
+  process.exit(code);
+});
 
 meteor.stdout.on('data', function startTesting(data) {
   var data = data.toString();


### PR DESCRIPTION
If mrt fails, error code is lost and make still succeeds. We have to catch the error code and pass it on.
