### PR TITLE
Allow testing in production mode

### DIFF
--- a/start_test.js
+++ b/start_test.js
@@ -3,6 +3,9 @@ var spawn = require('child_process').spawn;
 
 var workingDir = process.env.WORKING_DIR || process.env.PACKAGE_DIR || './';
 var args = ['test-packages', '--once', '--driver-package', 'test-in-console', '-p', 10015];
+if (process.env.PRODUCTION) {
+  args.push('--production');
+}
 if (typeof process.env.PACKAGES === 'undefined') {
   args.push('./');
 }


### PR DESCRIPTION
I found tests sometimes fail in production mode because code is minimized. This allows testing in production mode if wanted.
