### PR TITLE
Update configure.sh

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -11,4 +11,4 @@ curl https://install.meteor.com | /bin/sh
 #installing meteorite
 npm install -g meteorite
 
-mrt update
+mrt update --force


### PR DESCRIPTION
Added `--force` flag to `mrt update` to account for packages that may contain conflicting dependencies.

For example : 

`luma-component` contains an example app that references itself locally, but also uses the `jquery-select2` package. `luma-component` is a dependency of `jquery-select2` so the local reference conflicts with the version of `luma-component` on atmosphere.

package smart.json

``` javascript
{
  "name": "luma-component",
  "description": "Blaze component mixins and base class",
  "homepage": "https://github.com/LumaPictures/meteor-luma-component",
  "author": "Austin Rivas <austinrivas@gmail.com> (https://github.com/austinrivas)",
  "version": "1.0.3",
  "git": "https://github.com/LumaPictures/meteor-luma-component",
  "packages": {}
}
```

example app smart.json

``` javascript
{
  "packages": {
    "luma-component": {
      "path": ".."
    },
    "luma-ui": {},
    "jquery-select2": {}
  }
}
```
