### PR TITLE
Added changeable meteor version

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,6 @@ You can configure tests with two environment variables:
  * `WORKING_DIR` -- working directory to run `mrt` from
  * `PACKAGES` -- list of package names or directories to test, separated by `;`, by default `./`; specfiy empty string to test all packages
  * `TEST_COMMAND` -- you can specify a custom command to run, instead of default `mrt`, it gets all the arguments `mrt` would; this is useful if you want to do some more pre- or post-processing
+ * `METEOR_RELEASE` -- you can specify the meteor release to run the tests with.
 
 See [here](http://meteorhacks.com/travis-ci-support-for-meteor-packages.html) for more information

--- a/start_test.js
+++ b/start_test.js
@@ -3,12 +3,22 @@ var spawn = require('child_process').spawn;
 
 var workingDir = process.env.WORKING_DIR || process.env.PACKAGE_DIR || './';
 var args = ['test-packages', '--once', '--driver-package', 'test-in-console', '-p', 10015];
+
+
+if (typeof process.env.METEOR_RELEASE !== 'undefined' &&
+    process.env.METEOR_RELEASE !== '') {
+    args.push('--release');
+    args.push(process.env.METEOR_RELEASE);
+}
+
+
 if (typeof process.env.PACKAGES === 'undefined') {
   args.push('./');
 }
 else if (process.env.PACKAGES !== '') {
   args = args.concat(process.env.PACKAGES.split(';'));
 }
+
 var meteor = spawn((process.env.TEST_COMMAND || 'mrt'), args, {cwd: workingDir});
 meteor.stdout.pipe(process.stdout);
 meteor.stderr.pipe(process.stderr);


### PR DESCRIPTION
Some meteor packages are not compatible with 0.9.0 yet but should still be testable.

I added the possibility to set the meteor release to run the tests with using a env variable. Mitar mentionend needing this in #26 
