### PR TITLE
External script instructions added to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@ travis-ci-meteor-packages
 
 Add following file to your meteor package as `.travis.yml`
 
-    language: node_js
-    node_js:
-      - "0.10"
-    before_install:
-      - "curl -L http://git.io/ejPSng | /bin/sh"
+```yaml
+language: node_js
+node_js:
+  - "0.10"
+before_install:
+  - "curl -L http://git.io/ejPSng | /bin/sh"
+```
 
 Login to [https://travis-ci.org](https://travis-ci.org) with Github and navigate to [https://travis-ci.org/profile](https://travis-ci.org/profile)
 
@@ -22,5 +24,22 @@ You can configure tests with two environment variables:
  * `PACKAGES` -- list of package names or directories to test, separated by `;`, by default `./`; specfiy empty string to test all packages
  * `TEST_COMMAND` -- you can specify a custom command to run, instead of default `meteor`, it gets all the arguments `meteor` would; this is useful if you want to do some more pre- or post-processing
  * `METEOR_RELEASE` -- you can specify the meteor release to run the tests with.
+
+If you would like to specify more arguments (such as `--settings`), create a simple shell script and pass the path to `TEST_COMMAND`.
+
+Create the following `travis.sh` (name not important):
+```bash
+#!/bin/sh
+meteor "$@" --settings test/settings.travis.json
+```
+Add the following environment variable to your `.travis.yml`:
+```yaml
+env: TEST_COMMAND=./travis.sh
+```
+
+Be sure to set the executable flag on your new script:
+```bash
+$ chmod +x travis.sh
+```
 
 See [here](http://meteorhacks.com/travis-ci-support-for-meteor-packages.html) for more information


### PR DESCRIPTION
The extra script method does work just fine: https://travis-ci.org/numtel/meteor-mysql/builds/42587897

Preview updated readme: https://github.com/numtel/travis-ci-meteor-packages/blob/readme_external_script/README.md
